### PR TITLE
Remove Working Group info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This repository's issue tracker is used to discuss the 
 [Node.js Roadmap](https://github.com/nodejs/node/blob/master/ROADMAP.md).
 
-The code hosted in the `gh-pages` branch is for the legacy [io.js Roadmap](http://roadmap.iojs.org/) website and no further changes
-(Pull Requests) are needed.
-
-
-## Contributors Welcome
+The code hosted in the `gh-pages` branch is for the legacy [io.js Roadmap](http://roadmap.iojs.org/) website and no further changes (Pull Requests) are needed.
 
 Please use the issue tracker to share your ideas and participate on roadmap topics.
+
+## Members
+
+The Roadmap working group has been retired. The [CTC](https://github.com/nodejs/CTC) now maintains updates to the [Roadmap](https://github.com/nodejs/node/blob/master/ROADMAP.md).
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
-# Node.js roadmap
-
-This repository's issue tracker is used to discuss the 
-[Node.js Roadmap](https://github.com/nodejs/node/blob/master/ROADMAP.md).
+# Legacy io.js Roadmap
 
 The code hosted in the `gh-pages` branch is for the legacy [io.js Roadmap](http://roadmap.iojs.org/) website and no further changes (Pull Requests) are needed.
 
-Please use the issue tracker to share your ideas and participate on roadmap topics.
-
 ## Members
 
-The Roadmap working group has been retired. The [CTC](https://github.com/nodejs/CTC) now maintains updates to the [Roadmap](https://github.com/nodejs/node/blob/master/ROADMAP.md).
-
+The Roadmap working group has been retired.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,3 @@ The code hosted in the `gh-pages` branch is for the legacy [io.js Roadmap](http:
 
 Please use the issue tracker to share your ideas and participate on roadmap topics.
 
-
-## People
-
-Current WG Members:
-
-* Mikeal Rogers (@mikeal)
-* Bert Belder (@piscisaureus)
-* Chris Dickinson (@chrisdickinson)
-* Tierney Coren (@bnb)


### PR DESCRIPTION
See: https://github.com/nodejs/CTC/issues/16

This is the minimum change. What happens to the future of this repo can be another issue.

PLEASE NOTE: Not many people have access to merge this- so if YOU are one of the few people this will wait on YOU!

/cc @nodejs/ctc 
